### PR TITLE
Docs: README overhaul + Home Assistant dashboard template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,42 @@
-# Rain sensor
+# Rain sensor for Home Assistant
 
-A project which brings alive a rain bucket sensor with Wemos D1 mini to measure
-amount of water precipitation through MQTT to [Home Assistant](https://www.home-assistant.io/) using MQTT discovery.
+A DIY wireless rain gauge built around a **Wemos D1 mini (ESP8266)** and the
+**MS-WH-SP-RG** tipping-bucket sensor. It measures precipitation and reports it
+to [Home Assistant](https://www.home-assistant.io/) over MQTT — with automatic
+discovery, a built-in web dashboard, and over-the-air firmware updates.
+
+- 🌧 **Accurate tip counting** — hardware interrupt with software debounce
+- 📊 **Rich statistics** — total, rate (mm/h), today / week / month / year
+- 🏠 **Home Assistant MQTT discovery** — entities appear automatically
+- 🌐 **Built-in web dashboard** — live charts, served straight from the device
+- 🔧 **Captive-portal setup** — pick WiFi + enter MQTT, no credentials in code
+- ⬆️ **OTA updates** — flash new firmware from the browser
+- ⏱ **NTP time sync** — correct daily / weekly / monthly / yearly resets
+
+## Demo
+
+You can try the device's web interface without any hardware — it is a static
+snapshot of the real dashboard:
+
+▶️ **[Live demo](https://htmlpreview.github.io/?https://github.com/JH-Soft-Technology/ha-rain-sensor/blob/master/demo/index.html)**
+
+![Web dashboard overview](https://raw.githubusercontent.com/JH-Soft-Technology/ha-rain-sensor/master/demo/screenshot-overview.png)
+
+## What's in this repository
+
+| Path | Contents |
+|---|---|
+| `src/` | Firmware source (`main.cpp`) |
+| `demo/` | Static preview of the web dashboard + screenshot |
+| `3d_print/` | STL files for the sensor mount |
+| `content/` | Wiring schematic and other images |
+| `platformio.ini` | PlatformIO build configuration |
+| `firmware-x.y.z.bin` | Pre-built firmware for OTA flashing |
 
 ## Used hardware
 
 - Rain bucket sensor [MS-WH-SP-RG](https://www.laskakit.cz/ms-wh-sp-rg-srazkomer/)
-- [Wemos D1 mini](https://www.laskakit.cz/wemos-d1-mini-esp8266-wifi-modul/) development board
-
-## Dev platform
-
-- [Visual Studio Code](https://code.visualstudio.com/) - pretty good and customizable tool
-- [PlatformIO](https://platformio.org/) - can be extension into the Visual studio code and can substitute traditional Arduino IDE.
-
-## Environment
-
-It is using mqtt protocol to brings data from hardware into the digital world. tailor-made for the [home assistant](https://www.home-assistant.io/) environment.
-
-## STL files
-
-- Pipe holder with 50 mm diameter and arm to hold the rain sensor. Used 6 M4 screws with nuts. Sensor is bolted to the arm with self-tapping screw.
-
-  - [Pipe holder part 1](https://github.com/JH-Soft-Technology/ha-rain-sensor/blob/master/3d_print/rain%20sensor%20tube%20holder%20part%201.stl)
-  - [Pipe holder part 2](https://github.com/JH-Soft-Technology/ha-rain-sensor/blob/master/3d_print/rain%20sensor%20tube%20holder%20part%202.stl)
-  - [Arm holder](https://github.com/JH-Soft-Technology/ha-rain-sensor/blob/master/3d_print/Rain%20sensor%20arm.stl)
+- [Wemos D1 mini](https://www.laskakit.cz/wemos-d1-mini-esp8266-wifi-modul/) development board (4 MB flash, needed for OTA)
 
 ## Wiring
 
@@ -37,7 +50,7 @@ recommended:
 - `1 kΩ` resistor in series with the reed switch (limits the capacitor's
   discharge current and protects the reed contacts)
 
-![Recommended input wiring](https://github.com/JH-Soft-Technology/ha-rain-sensor/blob/master/content/images/reed-switch-debounce-wiring.png)
+![Recommended input wiring](https://raw.githubusercontent.com/JH-Soft-Technology/ha-rain-sensor/master/content/images/reed-switch-debounce-wiring.png)
 
 For a short cable next to the board the internal `INPUT_PULLUP` plus the
 software debounce is usually enough.
@@ -48,44 +61,68 @@ No credentials are stored in the source code. WiFi and MQTT are configured
 through a captive portal on first boot:
 
 1. Install the [MQTT](https://www.home-assistant.io/integrations/mqtt/) integration in Home Assistant and configure the broker.
-2. Build and flash the firmware via PlatformIO (4 MB board, `littlefs` filesystem).
-3. On first boot the device opens a WiFi access point named **`RainSensor-Setup`**.
-   Connect to it with a phone or laptop.
-4. In the portal, pick your WiFi network, enter its password, and fill in the
-   MQTT host, port, user and password. Save.
-5. The device reboots, connects, and a new rain sensor device appears in the
-   MQTT integration automatically.
+2. Build and flash the firmware via PlatformIO (4 MB board, `littlefs` filesystem), or upload a pre-built `firmware-x.y.z.bin`.
+3. On first boot the device opens a WiFi access point named **`RainSensor-Setup`**. Connect to it with a phone or laptop.
+4. In the portal, pick your WiFi network, enter its password, and fill in the MQTT host, port, user and password. Save.
+5. The device reboots, connects, and a new rain sensor device appears in the MQTT integration automatically.
 
-The settings are stored on the device (LittleFS), so they survive reboots and
+Settings are stored on the device (LittleFS), so they survive reboots and
 firmware updates.
 
-## Web interface and OTA updates
+## Web dashboard and OTA updates
 
-Once connected, the device serves a small web UI on its IP address (shown in the
-serial log and your router):
+Once connected, the device serves a dashboard on its IP address (shown in the
+serial log and your router). It has two tabs:
 
-- `/` — live status: total rain, rate, raining, WiFi signal, IP, uptime, free memory, MQTT state
-- `/update` — upload a new firmware `.bin` straight from the browser (ElegantOTA)
-- `/resetwifi` — clear WiFi settings and reopen the setup portal
+- **Overview** — "raining now" with current rate, plus today / week / month / year totals, each with a bar chart.
+- **Device** — IP address, WiFi signal, MQTT status, uptime, free memory and total rain since boot.
+
+Two actions are available from the header:
+
+- **Update** (`/update`) — upload a new firmware `.bin` straight from the browser (ElegantOTA).
+- **Reset WiFi** (`/resetwifi`) — clear WiFi settings and reopen the setup portal.
+
+The [live demo](https://htmlpreview.github.io/?https://github.com/JH-Soft-Technology/ha-rain-sensor/blob/master/demo/index.html) shows exactly this interface.
 
 ## Entities exposed in Home Assistant
 
-All values are sent in a single JSON message and split into entities via value templates:
+All values are sent in a single JSON message and split into entities via value
+templates, so the device only publishes one MQTT message per update.
 
-| Entity | Type | Notes |
-|---|---|---|
-| Rain | sensor (mm) | cumulative, `state_class: total_increasing` |
-| Rain rate | sensor (mm/h) | `device_class: precipitation_intensity` |
-| Raining | binary_sensor | on while it rained in the last 6 min |
-| WiFi signal | sensor (dBm) | diagnostic |
-| Uptime | sensor (s) | diagnostic |
-| Free memory | sensor (B) | diagnostic |
+| Entity | Type | Unit | Notes |
+|---|---|---|---|
+| Rain | sensor | mm | cumulative, `state_class: total_increasing` |
+| Rain rate | sensor | mm/h | `device_class: precipitation_intensity` |
+| Rain today | sensor | mm | resets at local midnight |
+| Rain this week | sensor | mm | resets Monday |
+| Rain this month | sensor | mm | resets on the 1st |
+| Rain this year | sensor | mm | resets on Jan 1 |
+| Raining | binary_sensor | — | on while it rained in the last 6 min |
+| WiFi signal | sensor | dBm | diagnostic |
+| Uptime | sensor | s | diagnostic |
+| Free memory | sensor | B | diagnostic |
 
-The cumulative rain uses `total_increasing`, so Home Assistant automatically
-tracks resets (after a reboot) and calculates hourly / daily / monthly
-statistics. Use a `utility_meter` helper for per-day or per-week resets.
+The period totals reset on real calendar boundaries thanks to **NTP time sync**
+(CET/CEST). The cumulative rain uses `total_increasing`, so Home Assistant
+tracks resets (after a reboot) and can build its own long-term statistics.
 
 The send interval adapts automatically: **every 60 s** while it is raining,
 **every 30 min** after 20 minutes without rain.
+
+## Build and development
+
+- [Visual Studio Code](https://code.visualstudio.com/) with the [PlatformIO](https://platformio.org/) extension.
+- Open the project, connect the Wemos D1 mini, and run *Upload*. After the first flash, further updates can be done over WiFi from the `/update` page.
+
+## STL files
+
+Pipe holder (50 mm diameter) with an arm to hold the rain sensor. Uses 6 M4
+screws with nuts; the sensor is bolted to the arm with a self-tapping screw.
+
+- [Pipe holder part 1](https://github.com/JH-Soft-Technology/ha-rain-sensor/blob/master/3d_print/rain%20sensor%20tube%20holder%20part%201.stl)
+- [Pipe holder part 2](https://github.com/JH-Soft-Technology/ha-rain-sensor/blob/master/3d_print/rain%20sensor%20tube%20holder%20part%202.stl)
+- [Arm holder](https://github.com/JH-Soft-Technology/ha-rain-sensor/blob/master/3d_print/Rain%20sensor%20arm.stl)
+
+---
 
 [![buy me a coffee](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/jhoralek)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ snapshot of the real dashboard:
 |---|---|
 | `src/` | Firmware source (`main.cpp`) |
 | `demo/` | Static preview of the web dashboard + screenshot |
+| `home-assistant/` | Ready-to-use Home Assistant dashboard template |
 | `3d_print/` | STL files for the sensor mount |
 | `content/` | Wiring schematic and other images |
 | `platformio.ini` | PlatformIO build configuration |
@@ -108,6 +109,23 @@ tracks resets (after a reboot) and can build its own long-term statistics.
 
 The send interval adapts automatically: **every 60 s** while it is raining,
 **every 30 min** after 20 minutes without rain.
+
+## Recreate the device dashboard in Home Assistant
+
+The per-hour / per-day / per-month bar charts you see on the device are rendered
+locally and are **not** sent over MQTT — there is no need to. Home Assistant can
+rebuild them from the cumulative `Rain` sensor (`total_increasing`), which feeds
+HA's long-term statistics.
+
+A ready-to-use template is provided in
+[`home-assistant/rain-sensor-homeassistant.yaml`](home-assistant/rain-sensor-homeassistant.yaml). It contains:
+
+- `utility_meter` helpers for today / week / month / year (HA-side resets)
+- a Lovelace dashboard mirroring the device's **Overview** and **Device** tabs, with bar charts built from the built-in `statistics-graph` card (no HACS required)
+- an optional ApexCharts variant for nicer bars
+
+Check the entity IDs at the top of the file against your install
+(Settings → Devices & Services → Entities) before pasting it in.
 
 ## Build and development
 

--- a/home-assistant/rain-sensor-homeassistant.yaml
+++ b/home-assistant/rain-sensor-homeassistant.yaml
@@ -1,0 +1,216 @@
+# =============================================================================
+#  Rain sensor  ->  Home Assistant template
+#  Replikuje palubní dashboard zařízení (Overview + Device) přímo v HA.
+# =============================================================================
+#
+#  PŘEDPOKLAD: senzor je už přidaný přes MQTT discovery.
+#
+#  !!! NEŽ TO POUŽIJEŠ: ověř entity_id !!!
+#  Settings -> Devices & Services -> Entities (filtruj "Rain sensor"),
+#  nebo Developer Tools -> States. Níže používám tyto odhadnuté id
+#  (HA je skládá jako <nazev zarizeni>_<nazev entity>):
+#
+#    sensor.rain_sensor_rain            (kumulativní úhrn, total_increasing)  <- KLÍČOVÝ
+#    sensor.rain_sensor_rain_rate       (mm/h)
+#    sensor.rain_sensor_rain_today
+#    sensor.rain_sensor_rain_this_week
+#    sensor.rain_sensor_rain_this_month
+#    sensor.rain_sensor_rain_this_year
+#    sensor.rain_sensor_wifi_signal     (dBm, diagnostic)
+#    sensor.rain_sensor_uptime          (s, diagnostic)
+#    sensor.rain_sensor_free_memory     (B, diagnostic)
+#    binary_sensor.rain_sensor_raining
+#
+#  Pokud se tvoje liší, jen je v této šabloně nahraď (Najít/Nahradit).
+# =============================================================================
+
+
+# =============================================================================
+#  ČÁST 1 — configuration.yaml
+# -----------------------------------------------------------------------------
+#  utility_meter helpery: počítají dnes/týden/měsíc/rok z KUMULATIVNÍHO
+#  senzoru, s resetem řízeným časovou zónou HA (Europe/Prague). Jsou to
+#  alternativa k firmwarovým sensor.rain_sensor_rain_today/week/month/year —
+#  použij, co ti vyhovuje. Výhoda HA verze: reset přesně podle HA, historie
+#  v dlouhodobých statistikách.
+#
+#  Vlož do configuration.yaml (nebo do packages) a restartuj HA.
+# =============================================================================
+
+utility_meter:
+  rain_today_ha:
+    source: sensor.rain_sensor_rain
+    name: Rain today (HA)
+    cycle: daily
+  rain_week_ha:
+    source: sensor.rain_sensor_rain
+    name: Rain this week (HA)
+    cycle: weekly
+  rain_month_ha:
+    source: sensor.rain_sensor_rain
+    name: Rain this month (HA)
+    cycle: monthly
+  rain_year_ha:
+    source: sensor.rain_sensor_rain
+    name: Rain this year (HA)
+    cycle: yearly
+
+
+# =============================================================================
+#  ČÁST 2 — Lovelace dashboard
+# -----------------------------------------------------------------------------
+#  Zkopíruj NÍŽE uvedené (od "title:" dál) do nového dashboardu:
+#  Settings -> Dashboards -> + Add dashboard -> (otevři) -> tři tečky ->
+#  Edit dashboard -> tři tečky -> Raw configuration editor -> vlož.
+#
+#  Grafy po hodinách/dnech/měsících kreslí vestavěná karta
+#  "statistics-graph" z kumulativního senzoru (stat_types: sum + chart_type:
+#  bar = úhrn za každý sloupec, stejně jako Energy dashboard). Žádné HACS.
+#  Hezčí variantu přes ApexCharts najdeš na konci souboru.
+# =============================================================================
+
+title: Rain
+views:
+  # ----------------------------------------------------------------- Overview
+  - title: Overview
+    path: rain-overview
+    icon: mdi:weather-pouring
+    cards:
+      - type: heading
+        heading: Rain sensor
+        heading_style: title
+
+      # --- Prší teď + intenzita ---
+      - type: glance
+        title: Raining now
+        show_state: true
+        entities:
+          - entity: binary_sensor.rain_sensor_raining
+            name: Raining
+          - entity: sensor.rain_sensor_rain_rate
+            name: Rate
+
+      # --- Velká čísla period ---
+      - type: glance
+        columns: 4
+        state_color: false
+        entities:
+          - entity: sensor.rain_sensor_rain_today
+            name: Today
+          - entity: sensor.rain_sensor_rain_this_week
+            name: This week
+          - entity: sensor.rain_sensor_rain_this_month
+            name: This month
+          - entity: sensor.rain_sensor_rain_this_year
+            name: This year
+
+      # --- Dnes po hodinách ---
+      - type: statistics-graph
+        title: Today (per hour)
+        chart_type: bar
+        period: hour
+        days_to_show: 1
+        stat_types:
+          - sum
+        entities:
+          - sensor.rain_sensor_rain
+
+      # --- Tento týden po dnech ---
+      - type: statistics-graph
+        title: This week (per day)
+        chart_type: bar
+        period: day
+        days_to_show: 7
+        stat_types:
+          - sum
+        entities:
+          - sensor.rain_sensor_rain
+
+      # --- Tento měsíc po dnech ---
+      - type: statistics-graph
+        title: This month (per day)
+        chart_type: bar
+        period: day
+        days_to_show: 31
+        stat_types:
+          - sum
+        entities:
+          - sensor.rain_sensor_rain
+
+      # --- Tento rok po měsících ---
+      - type: statistics-graph
+        title: This year (per month)
+        chart_type: bar
+        period: month
+        days_to_show: 365
+        stat_types:
+          - sum
+        entities:
+          - sensor.rain_sensor_rain
+
+  # ------------------------------------------------------------------- Device
+  - title: Device
+    path: rain-device
+    icon: mdi:chip
+    cards:
+      - type: heading
+        heading: Device
+        heading_style: title
+
+      - type: entities
+        entities:
+          - entity: sensor.rain_sensor_rain
+            name: Total since boot
+          - entity: binary_sensor.rain_sensor_raining
+            name: Raining
+          - entity: sensor.rain_sensor_rain_rate
+            name: Rate
+          - type: section
+            label: Diagnostics
+          - entity: sensor.rain_sensor_wifi_signal
+            name: WiFi signal
+          - entity: sensor.rain_sensor_uptime
+            name: Uptime
+          - entity: sensor.rain_sensor_free_memory
+            name: Free memory
+
+      # IP adresa zařízení se přes MQTT NEPOSÍLÁ (je jen na webu zařízení),
+      # takže ji v HA nenajdeš. Otevři přímo http://<ip-zarizeni>/ .
+
+      # --- HA utility_meter verze period (pokud je používáš místo firmwaru) ---
+      - type: entities
+        title: Period totals (HA utility_meter)
+        entities:
+          - sensor.rain_today_ha
+          - sensor.rain_week_ha
+          - sensor.rain_month_ha
+          - sensor.rain_year_ha
+
+
+# =============================================================================
+#  ČÁST 3 (VOLITELNÉ) — hezčí grafy přes ApexCharts (vyžaduje HACS)
+# -----------------------------------------------------------------------------
+#  Nainstaluj "apexcharts-card" přes HACS. ApexCharts umí přímo "diff" přírůstek
+#  z kumulativního senzoru => čisté sloupce úhrnu za hodinu/den/měsíc.
+#  Příklad nahrazuje kartu "Today (per hour)":
+#
+#  - type: custom:apexcharts-card
+#    header:
+#      show: true
+#      title: Today (per hour)
+#    graph_span: 24h
+#    span:
+#      start: day
+#    series:
+#      - entity: sensor.rain_sensor_rain
+#        name: Rain
+#        type: column
+#        unit: mm
+#        group_by:
+#          func: diff      # přírůstek = úhrn za interval
+#          duration: 1h
+#
+#  Pro týden:   graph_span: 7d,  group_by duration: 1d,  span start: week
+#  Pro měsíc:   graph_span: 31d, group_by duration: 1d,  span start: month
+#  Pro rok:     graph_span: 365d,group_by duration: 1month (resp. 30d)
+# =============================================================================


### PR DESCRIPTION
Vylepšená dokumentace + hotová HA šablona.

## README
- Úvod s přehledem featur
- **Demo sekce** — screenshot + živý odkaz (htmlpreview)
- Tabulka "What's in this repository"
- Aktualizovaný popis web dashboardu (taby, grafy, OTA)
- Kompletní tabulka HA entit (today/week/month/year, diagnostika)
- Nová sekce **"Recreate the device dashboard in Home Assistant"**

## home-assistant/rain-sensor-homeassistant.yaml (nový)
Hotová šablona, která zreplikuje palubní dashboard v HA:
- `utility_meter` helpery (dnes/týden/měsíc/rok, reset dle HA)
- Lovelace dashboard zrcadlící taby Overview + Device
- Sloupcové grafy přes vestavěnou `statistics-graph` (bez HACS), úhrn počítán z kumulativního `total_increasing` senzoru
- Volitelná ApexCharts varianta
- Nahoře jasně označené entity_id k ověření

Čistě dokumentace + konfigurační šablona, žádné změny firmwaru.