### PR TITLE
Persist cumulative rain total across reboots (fixes HA charts)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,7 @@
   author: Jiri Horalek
   email: horalek.jiri@gmail.com
   site: https://github.com/JH-Soft-Technology/ha-rain-sensor
-  version: 0.6.0
+  version: 0.6.1
   last change: 04.06.2026
 */
 #include <Arduino.h>
@@ -29,7 +29,7 @@
 #include <time.h>
 
 #define MODEL      "rainy 0.0.2"
-#define SW_VERSION "0.6.0"
+#define SW_VERSION "0.6.1"
 
 #define MQTT_MAX_TRANSFER_SIZE 1024
 #define MQTT_INSTANCE_NAME     "ha-rain-sensor"
@@ -190,9 +190,10 @@ void load_stats()
   if (!LittleFS.exists("/stats.json")) return;
   File f = LittleFS.open("/stats.json", "r");
   if (!f) return;
-  DynamicJsonDocument doc(256);
+  DynamicJsonDocument doc(320);
   if (deserializeJson(doc, f)) { f.close(); return; }
   f.close();
+  total_rain_mm = doc["total"] | 0.0f;
   rain_today_mm = doc["today"] | 0.0f;
   rain_week_mm  = doc["week"]  | 0.0f;
   rain_month_mm = doc["month"] | 0.0f;
@@ -205,7 +206,8 @@ void load_stats()
 
 void save_stats()
 {
-  DynamicJsonDocument doc(256);
+  DynamicJsonDocument doc(320);
+  doc["total"] = total_rain_mm;
   doc["today"] = rain_today_mm;
   doc["week"]  = rain_week_mm;
   doc["month"] = rain_month_mm;
@@ -858,7 +860,7 @@ void handle_root()
     "<tr><td>MQTT</td><td>%s</td></tr>"
     "<tr><td>Uptime</td><td>%lu s</td></tr>"
     "<tr><td>Free memory</td><td>%u B</td></tr>"
-    "<tr><td>Total since boot</td><td>%.2f mm</td></tr>"
+    "<tr><td>Total</td><td>%.2f mm</td></tr>"
     "<tr><td>Time (NTP)</td><td>%s</td></tr>"
     "</table>",
     WiFi.localIP().toString().c_str(),


### PR DESCRIPTION
## Problém
Kumulativní `total_rain_mm` (entita `sensor.rain_sensor_rain*`, `state_class: total_increasing`) se **neukládal do LittleFS**, takže se při každém rebootu vynuloval na 0 — na rozdíl od period hodnot (today/week/month/year), které persistované jsou.

Důsledek: entita nebyla doopravdy „stále rostoucí", ale pilovitá. Home Assistant z ní nedokázal poskládat správné denní/týdenní statistiky → grafy úhrnu vycházely špatně a posunuté (sum skoro nula, max o den vedle).

## Oprava
- `total_rain_mm` se ukládá a načítá z `/stats.json` (`save_stats`/`load_stats`) stejně jako period hodnoty
- Kapacita JSON dokumentu 256 → 320 (jeden klíč navíc)
- Rollover logika `total_rain_mm` nikdy nenuluje → entita je teď opravdu monotónní
- Web label "Total since boot" → "Total" (hodnota už přežívá reboot)
- Verze 0.6.1

## Po flashnutí
Kumulativní senzor začne růst od poslední uložené hodnoty a přežije reboot. Tím se narovná i graf v HA — sum per den/týden/měsíc bude konečně sedět (platí dopředu; historická data z období rebootů se zpětně nedopočítají).

Ověř build/flash v PlatformIO.