### PR TITLE
HA template: stat_types change (not sum) for correct daily rain bars

### DIFF
--- a/home-assistant/rain-sensor-homeassistant.yaml
+++ b/home-assistant/rain-sensor-homeassistant.yaml
@@ -76,8 +76,8 @@ utility_meter:
 #  Edit dashboard -> tři tečky -> Raw configuration editor -> vlož.
 #
 #  Grafy po hodinách/dnech/měsících kreslí vestavěná karta
-#  "statistics-graph" z kumulativního senzoru (stat_types: sum + chart_type:
-#  bar = úhrn za každý sloupec, stejně jako Energy dashboard). Žádné HACS.
+#  "statistics-graph" z kumulativního senzoru (stat_types: change + chart_type:
+#  bar = přírůstek za každý sloupec = úhrn za to období). Žádné HACS.
 #  Hezčí variantu přes ApexCharts najdeš na konci souboru.
 # =============================================================================
 
@@ -123,7 +123,7 @@ views:
         period: hour
         days_to_show: 1
         stat_types:
-          - sum
+          - change
         entities:
           - sensor.rain_sensor_rain
 
@@ -134,7 +134,7 @@ views:
         period: day
         days_to_show: 7
         stat_types:
-          - sum
+          - change
         entities:
           - sensor.rain_sensor_rain
 
@@ -145,7 +145,7 @@ views:
         period: day
         days_to_show: 31
         stat_types:
-          - sum
+          - change
         entities:
           - sensor.rain_sensor_rain
 
@@ -156,7 +156,7 @@ views:
         period: month
         days_to_show: 365
         stat_types:
-          - sum
+          - change
         entities:
           - sensor.rain_sensor_rain
 


### PR DESCRIPTION
Oprava HA šablony — grafy úhrnu po dnech ukazovaly špatně.

## Problém
statistics-graph u stat_types: sum kreslí kumulativní hodnotu senzoru. U total_increasing srážkoměru to znamenalo, že po dešti hodnota zůstala a táhla se dál: v neděli naprší 2 mm → graf ukázal neděli 2, pondělí 2 i úterý 2.

## Oprava
Změna na stat_types: change, což kreslí přírůstek za dané období (rozdíl hodnoty mezi začátkem a koncem sloupce):
- neděle: 0 → 2 = 2 mm
- pondělí: 2 → 2 = 0
- úterý: 2 → 2 = 0

Opraveny všechny 4 grafy (dnes/týden/měsíc/rok) + komentář. Funguje díky tomu, že kumulativní senzor je teď monotónní (persist fix #26).

Čistě šablona, žádné změny firmwaru.
