### PR TITLE
Fix intermittent web server hang (socket exhaustion)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,7 @@
   author: Jiri Horalek
   email: horalek.jiri@gmail.com
   site: https://github.com/JH-Soft-Technology/ha-rain-sensor
-  version: 0.6.2
+  version: 0.6.3
   last change: 05.06.2026
 */
 #include <Arduino.h>
@@ -29,7 +29,7 @@
 #include <time.h>
 
 #define MODEL "rainy 0.0.2"
-#define SW_VERSION "0.6.2"
+#define SW_VERSION "0.6.3"
 
 #define MQTT_MAX_TRANSFER_SIZE 1024
 #define MQTT_INSTANCE_NAME "ha-rain-sensor"
@@ -828,6 +828,7 @@ void handle_root()
     strftime(time_str, sizeof(time_str), "%d.%m.%Y %H:%M", &ti);
   bool rain = raining_now();
 
+  server.sendHeader("Connection", "close");
   server.setContentLength(CONTENT_LENGTH_UNKNOWN);
   server.send(200, "text/html", "");
 
@@ -836,7 +837,6 @@ void handle_root()
       "<!DOCTYPE html><html><head>"
       "<meta charset='utf-8'>"
       "<meta name='viewport' content='width=device-width,initial-scale=1'>"
-      "<meta http-equiv='refresh' content='10'>"
       "<title>Rain sensor</title><style>"
       "*{box-sizing:border-box;margin:0;padding:0}"
       "body{font-family:-apple-system,BlinkMacSystemFont,sans-serif;"


### PR DESCRIPTION
Občas se webové rozhraní zaseklo a přestalo být dostupné, i když MQTT do HA vysílal dál.

## Příčina
Stavová stránka se sama obnovovala každých 10 s (meta refresh) a odpovědi neměly Connection: close. ESP8266 má jen ~5 lwIP socketů — opakovaná spojení z auto-refreshe se neuvolňovala dost rychle, takže web server po čase přestal přijímat spojení. MQTT má vlastní dlouhoživotní socket, proto jel dál → web mrtvý, data v HA OK.

## Oprava
- Auto-refresh úplně odstraněn. Stránka stejně při každém načtení vyrenderuje aktuální hodnoty; obnovu si uživatel udělá přes F5. Méně spojení = žádné vyčerpání socketů.
- Posílá se Connection: close, takže každý požadavek po odbavení uvolní svůj socket.
- Verze 0.6.3

## Jak ověřit
Po flashnutí nech běžet a sleduj senzor Free memory — měl by být stabilní. Web by se už neměl zasekávat. Kdyby problém přetrvával (nepravděpodobné), dalším krokem by bylo zvýšit počet TCP socketů v lwIP přes build flag.

Čistě firmware, žádné změny šablon.
